### PR TITLE
fix: about and posts links now work when site is hosted

### DIFF
--- a/pages/posts/2024-01-27-posts.md
+++ b/pages/posts/2024-01-27-posts.md
@@ -2,7 +2,7 @@
 title: Posts!
 date-published: 2024-01-27
 draft: true
-template: ../../templates/post.html
+template: post.template.html
 tags:
   - blog
 ---

--- a/pages/posts/post.template.html
+++ b/pages/posts/post.template.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title></title>
-  <link rel="stylesheet" href="../pages/style.css">
-  <link rel="stylesheet" href="../pages/posts.css">
+  <link rel="stylesheet" href="../style.css">
+  <link rel="stylesheet" href="../posts.css">
 </head>
 <body>
   <header class="site-wide">
@@ -13,15 +13,15 @@
       <h1 class="logo">Chris Newton</h1>
       <a href="https://github.com/chrisnewtn" rel="me">
         <picture class="social">
-          <source srcset="../pages/assets/github-mark-white.svg" media="(prefers-color-scheme: dark)">
-          <img src="../pages/assets/github-mark.svg" alt="The GitHub Octocat logo">
+          <source srcset="../assets/github-mark-white.svg" media="(prefers-color-scheme: dark)">
+          <img src="../assets/github-mark.svg" alt="The GitHub Octocat logo">
         </picture>
       </a>
     </div>
     <nav>
       <ul>
-        <li><a href="../public/index.html">About</a></li>
-        <li><a href="../public/posts/index.html">Posts</a></li>
+        <li><a href="../index.html">About</a></li>
+        <li><a href="index.html">Posts</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
My favourite kind of fix, just cheat! These relative links can't break the way that they did anymore if the template is in the same directory as all the other files that link to one another.