### PR TITLE
chore: increase image size limit to 1.5MiB

### DIFF
--- a/scripts/doc-processor/src/unified-plugins/optimizeImages.js
+++ b/scripts/doc-processor/src/unified-plugins/optimizeImages.js
@@ -85,7 +85,7 @@ export default function optimizeImages({
     await fs.writeFile(pathToNewImage, image.buffer);
 
     // throw this after the image is written to hopefully help with diagnostics.
-    if (image.info.size > 1 * mebibyte) {
+    if (image.info.size > 1.5 * mebibyte) {
       throw new Error(`Image too large (${toMiB(image.info.size)}) ${pathToNewImage}`);
     }
 


### PR DESCRIPTION
A cheap way to fix the build, but I prefer this to history editing.